### PR TITLE
Allow PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Access Control Checker Easy Neat Thorough",
     "type": "symfony-bundle",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "symfony/config": "^4.0|^5.0",
         "symfony/console": "^4.0|^5.0",
         "symfony/dependency-injection": "^4.0|^5.0",


### PR DESCRIPTION
Api platform and Symfony now support PHP 8.0, we should probably support the same versions.
