### PR TITLE
Allow security post-denormalize checks

### DIFF
--- a/src/AccessControl/RouteAccessControlFactory.php
+++ b/src/AccessControl/RouteAccessControlFactory.php
@@ -76,8 +76,9 @@ class RouteAccessControlFactory
             try {
                 $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
                 $attributes = AttributesExtractor::extractAttributes($route->getDefaults());
-                $isGranted = $resourceMetadata->getOperationAttribute($attributes, 'security', null, true);
-                if (null === $isGranted) {
+                $securityAttribute = $resourceMetadata->getOperationAttribute($attributes, 'security', null, true);
+                $securityPostDenormalizeAttribute = $resourceMetadata->getOperationAttribute($attributes, 'security_post_denormalize', null, true);
+                if (null === $securityAttribute && null === $securityPostDenormalizeAttribute) {
                     $isGranted = RouteAccessControlData::NO_ACCESS_CONTROL;
                 }
             } catch (ResourceClassNotFoundException $e) {


### PR DESCRIPTION
ApiPlatform allows security checks post denormalization:
https://api-platform.com/docs/core/security/#executing-access-control-rules-after-denormalization

This is useful for creation checks for instance.
They recommend not using both attributes at the same time, so we need to check both here.