### PR TITLE
Add api-platform 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,14 @@ ACCENT (Access Control Checker Easy Neat Thorough) is a Symfony command to check
 
 ## Installation
 
-### Make sure composer knows how to access the bundle
-
-Add the path to the private repository in your composer.json:
-```json
-"repositories": [
-    {
-        "type": "vcs",
-        "url": "https://github.com/theodo/accent"
-    }
-]
-```
-
 ### Require the bundle
 
 ```bash
-composer require --dev forge/accent-bundle
+composer require --dev theodo/accent-bundle
 ```
 
 ### Run the command
 
 ```bash
-bin/console forge:access-control
+bin/console theodo:access-control
 ```

--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,13 @@
     "description": "Access Control Checker Easy Neat Thorough",
     "type": "symfony-bundle",
     "require": {
-        "php": "^7.1|^8.0",
-        "symfony/config": "^4.0|^5.0|^6.0",
-        "symfony/console": "^4.0|^5.0|^6.0",
-        "symfony/dependency-injection": "^4.0|^5.0|^6.0",
-        "symfony/http-kernel": "^4.0|^5.0|^6.0",
-        "symfony/routing": "^4.0|^5.0|^6.0",
-        "api-platform/core": "^2.5"
+        "php": "^8.0",
+        "symfony/config": "^6.0",
+        "symfony/console": "^6.0",
+        "symfony/dependency-injection": "^6.0",
+        "symfony/http-kernel": "^6.0",
+        "symfony/routing": "^6.0",
+        "api-platform/core": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "forge/accent-bundle",
     "description": "Access Control Checker Easy Neat Thorough",
     "type": "symfony-bundle",
+    "keywords": ["security","api-platform","symfony","acl","checks"],
     "require": {
         "php": "^8.0",
         "symfony/config": "^6.0",
@@ -21,6 +22,10 @@
         {
             "name": "Paul Molin",
             "email": "paulm@theodo.fr"
+        },
+        {
+            "name": "Kevin Raynel",
+            "email": "kevinr@theodo.fr"
         }
     ],
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "forge/accent-bundle",
+    "name": "theodo/accent-bundle",
     "description": "Access Control Checker Easy Neat Thorough",
     "type": "symfony-bundle",
     "keywords": ["security","api-platform","symfony","acl","checks"],
@@ -14,7 +14,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Forge\\AccentBundle\\": "src/"
+            "Theodo\\AccentBundle\\": "src/"
         }
     },
     "license": "MIT",

--- a/src/AccessControl/AccentReport.php
+++ b/src/AccessControl/AccentReport.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Forge\AccentBundle\AccessControl;
+namespace Theodo\AccentBundle\AccessControl;
 
 class AccentReport
 {

--- a/src/AccessControl/AccentReportFactory.php
+++ b/src/AccessControl/AccentReportFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Forge\AccentBundle\AccessControl;
+namespace Theodo\AccentBundle\AccessControl;
 
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;

--- a/src/AccessControl/RouteAccessControlData.php
+++ b/src/AccessControl/RouteAccessControlData.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Forge\AccentBundle\AccessControl;
+namespace Theodo\AccentBundle\AccessControl;
 
 use Symfony\Component\Routing\Route;
 

--- a/src/AccessControl/RouteAccessControlData.php
+++ b/src/AccessControl/RouteAccessControlData.php
@@ -11,6 +11,7 @@ class RouteAccessControlData
     public const NO_ACCESS_CONTROL = 'NO_ACCESS_CONTROL';
     public const NOT_API_PLATFORM_ROUTE = 'NOT_API_PLATFORM_ROUTE';
     public const RESOURCE_NOT_FOUND = 'RESOURCE_NOT_FOUND';
+    public const OPERATION_NOT_FOUND = 'OPERATION_NOT_FOUND';
     public const RESOURCE_UNRELATED_ROUTE = 'RESOURCE_UNRELATED_ROUTE';
 
     private $route;

--- a/src/AccessControl/RouteAccessControlFactory.php
+++ b/src/AccessControl/RouteAccessControlFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Forge\AccentBundle\AccessControl;
+namespace Theodo\AccentBundle\AccessControl;
 
 use ApiPlatform\Exception\OperationNotFoundException;
 use ApiPlatform\Exception\ResourceClassNotFoundException;

--- a/src/AccessControl/RouteAccessControlFactory.php
+++ b/src/AccessControl/RouteAccessControlFactory.php
@@ -4,22 +4,17 @@ declare(strict_types=1);
 
 namespace Forge\AccentBundle\AccessControl;
 
-use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Exception\OperationNotFoundException;
+use ApiPlatform\Exception\ResourceClassNotFoundException;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use Symfony\Component\Routing\Route;
 
 class RouteAccessControlFactory
 {
-    private $resourceMetadataFactory;
-    private $judge;
-
     public function __construct(
-        ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory,
-        RouteAccessControlJudge $routeAccessControlJudge
+        private ?ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory,
+        private RouteAccessControlJudge $judge
     ) {
-        $this->resourceMetadataFactory = $resourceMetadataFactory;
-        $this->judge = $routeAccessControlJudge;
     }
 
     public function createRouteAccessControlData(string $name, Route $route): RouteAccessControlData
@@ -59,7 +54,7 @@ class RouteAccessControlFactory
 
         if ($resourceClass) {
             try {
-                $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+                $resourceMetadata = $this->resourceMetadataCollectionFactory->create($resourceClass);
                 $operation = $resourceMetadata->getOperation($operationName);
 
                 $isGranted = $operation->getSecurity();

--- a/src/AccessControl/RouteAccessControlJudge.php
+++ b/src/AccessControl/RouteAccessControlJudge.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Forge\AccentBundle\AccessControl;
+namespace Theodo\AccentBundle\AccessControl;
 
 class RouteAccessControlJudge
 {

--- a/src/Command/AccessControlCheckerCommand.php
+++ b/src/Command/AccessControlCheckerCommand.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Forge\AccentBundle\Command;
+namespace Theodo\AccentBundle\Command;
 
-use Forge\AccentBundle\AccessControl\AccentReportFactory;
-use Forge\AccentBundle\Descriptor\AccessControlDescriptor;
+use Theodo\AccentBundle\AccessControl\AccentReportFactory;
+use Theodo\AccentBundle\Descriptor\AccessControlDescriptor;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand('forge:access-control', 'Check access control for each route.')]
+#[AsCommand('theodo:access-control', 'Check access control for each route.')]
 class AccessControlCheckerCommand extends Command
 {
     private $accentReportFactory;

--- a/src/Command/AccessControlCheckerCommand.php
+++ b/src/Command/AccessControlCheckerCommand.php
@@ -6,14 +6,15 @@ namespace Forge\AccentBundle\Command;
 
 use Forge\AccentBundle\AccessControl\AccentReportFactory;
 use Forge\AccentBundle\Descriptor\AccessControlDescriptor;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand('forge:access-control', 'Check access control for each route.')]
 class AccessControlCheckerCommand extends Command
 {
-    protected static $defaultName = 'forge:access-control';
     private $accentReportFactory;
 
     public function __construct(AccentReportFactory $accentReportFactory)
@@ -25,10 +26,6 @@ class AccessControlCheckerCommand extends Command
 
     protected function configure()
     {
-        $this->setDescription(
-            'Check access control for each route.'
-        );
-
         $this->setHelp(
             'This command checks all the protections set up for each route, and displays them in an elegant and understandable way.'
         );

--- a/src/DependencyInjection/TheodoAccentExtension.php
+++ b/src/DependencyInjection/TheodoAccentExtension.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Forge\AccentBundle\DependencyInjection;
+namespace Theodo\AccentBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-class ForgeAccentExtension extends Extension
+class TheodoAccentExtension extends Extension
 {
     /**
      * @throws \Exception

--- a/src/Descriptor/AccessControlDescriptor.php
+++ b/src/Descriptor/AccessControlDescriptor.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Forge\AccentBundle\Descriptor;
+namespace Theodo\AccentBundle\Descriptor;
 
-use Forge\AccentBundle\AccessControl\RouteAccessControlData;
+use Theodo\AccentBundle\AccessControl\RouteAccessControlData;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -12,7 +12,7 @@
         <service class="Forge\AccentBundle\AccessControl\RouteAccessControlFactory"
                  id="forge_accent.route_access_control_extractor"
         >
-            <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
             <argument type="service" id="forge_accent.route_access_control_judge" />
         </service>
         <service class="Forge\AccentBundle\AccessControl\AccentReportFactory"

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -5,29 +5,29 @@
         http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service class="Forge\AccentBundle\AccessControl\RouteAccessControlJudge"
-                 id="forge_accent.route_access_control_judge"
+        <service class="Theodo\AccentBundle\AccessControl\RouteAccessControlJudge"
+                 id="theodo_accent.route_access_control_judge"
         >
         </service>
-        <service class="Forge\AccentBundle\AccessControl\RouteAccessControlFactory"
-                 id="forge_accent.route_access_control_extractor"
+        <service class="Theodo\AccentBundle\AccessControl\RouteAccessControlFactory"
+                 id="theodo_accent.route_access_control_extractor"
         >
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
-            <argument type="service" id="forge_accent.route_access_control_judge" />
+            <argument type="service" id="theodo_accent.route_access_control_judge" />
         </service>
-        <service class="Forge\AccentBundle\AccessControl\AccentReportFactory"
-                 id="forge_accent.accent_report_factory">
-            <argument type="service" id="forge_accent.route_access_control_extractor" />
-            <argument type="service" id="forge_accent.route_access_control_judge" />
+        <service class="Theodo\AccentBundle\AccessControl\AccentReportFactory"
+                 id="theodo_accent.accent_report_factory">
+            <argument type="service" id="theodo_accent.route_access_control_extractor" />
+            <argument type="service" id="theodo_accent.route_access_control_judge" />
             <argument type="service" id="router" />
         </service>
-        <service class="Forge\AccentBundle\Command\AccessControlCheckerCommand"
-                 id="forge_accent.access_control_checker_command">
-            <argument type="service" id="forge_accent.accent_report_factory"/>
+        <service class="Theodo\AccentBundle\Command\AccessControlCheckerCommand"
+                 id="theodo_accent.access_control_checker_command">
+            <argument type="service" id="theodo_accent.accent_report_factory"/>
             <tag name="console.command"/>
         </service>
-        <service id="Forge\AccentBundle\Command\AccessControlCheckerCommand"
-                 alias="forge_accent.access_control_checker_command" />
+        <service id="Theodo\AccentBundle\Command\AccessControlCheckerCommand"
+                 alias="theodo_accent.access_control_checker_command" />
     </services>
 
 </container>

--- a/src/TheodoAccentBundle.php
+++ b/src/TheodoAccentBundle.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Forge\AccentBundle;
+namespace Theodo\AccentBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class ForgeAccentBundle extends Bundle
+class TheodoAccentBundle extends Bundle
 {
 }


### PR DESCRIPTION
Breaking change!

api platform à déprécié le service `api_platform.metadata.resource.metadata_factory` en 2.7 et l'a supprimé sur la version 3.

Todo:
- [x] Valider sur une api qu'on détecte bien les mêmes routes ouvertes
- [x] Corriger la déprécation sur la définition de la commande : `User Deprecated: Since symfony/console 6.1: Relying on the static property "$defaultName" for setting a command name is deprecated. Add the "Symfony\Component\Console\Attribute\AsCommand" attribute to the "Forge\AccentBundle\Command\AccessControlCheckerCommand" class instead.`